### PR TITLE
Response status code and error message when error getting token

### DIFF
--- a/ebay-oauth-csharp-client/eBay/ApiClient/Auth/OAuth2/OAuth2Api.cs
+++ b/ebay-oauth-csharp-client/eBay/ApiClient/Auth/OAuth2/OAuth2Api.cs
@@ -281,6 +281,8 @@ namespace eBay.ApiClient.Auth.OAuth2
             {
                 oAuthResponse.ErrorMessage = response.Content;
                 log.Error("Error in fetching the token. Error:" + oAuthResponse.ErrorMessage);
+                log.Error($"Response Status Code: {response.StatusCode}");
+                log.Error($"Response Error Message: {response.ErrorMessage}");
             }
             else
             {


### PR DESCRIPTION
Response status code and error message when error getting token

Was having a problem earlier where logs were just giving me "Error in 
fetching the tokken. Error:" and no error message appeneded. I've 
added logging for status code and error message so it's possible to see 
if there has been any sort of low-level error with the call.
