### PR TITLE
Added Proxy Configuration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -88,6 +88,12 @@ CredentialUtil.Load(“YAML config file path”);
 or
 CredentialUtil.Load(System.IO.StreamReader);
 
+- If needed, you can add an IWebProxy.
+[source,csharp]
+IWebProxy webProxy = new WebProxy();
+//Your configuration here
+ProxyUtil.WebProxy = webProxy;
+
 - Once the credentials are loaded, call any operation on **OAuth2Api**.
 1. **GetApplicationToken**: Use this operation when the application request an access token to access their own resources,
 not on behalf of a user. Learn more about https://developer.ebay.com/api-docs/static/oauth-client-credentials-grant.html[Client Credentials grant flow].

--- a/ebay-oauth-csharp-client/eBay/ApiClient/Auth/OAuth2/OAuth2Api.cs
+++ b/ebay-oauth-csharp-client/eBay/ApiClient/Auth/OAuth2/OAuth2Api.cs
@@ -243,6 +243,15 @@ namespace eBay.ApiClient.Auth.OAuth2
                 BaseUrl = new Uri(environment.ApiEndpoint())
             };
 
+            //Get proxy
+            IWebProxy proxy = ProxyUtil.WebProxy;
+
+            //Initialize proxy
+            if (proxy != null)
+            {
+                client.Proxy = proxy;
+            }
+
             //Create request
             RestRequest request = new RestRequest(Method.POST);
 

--- a/ebay-oauth-csharp-client/eBay/ApiClient/Auth/OAuth2/ProxyUtil.cs
+++ b/ebay-oauth-csharp-client/eBay/ApiClient/Auth/OAuth2/ProxyUtil.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace eBay.ApiClient.Auth.OAuth2
+{
+    public static class ProxyUtil
+    {
+        public static IWebProxy WebProxy;
+    }
+}
+


### PR DESCRIPTION
I had trouble getting the Access Token and found out that the RestClient had no way to configure an IWebProxy.
So I added  ProxyUtil to configure our proxy and now it works properly.

I added the usage in the README but if you want I can put it in a special section of the README instead.

