### PR TITLE
Multi-targeting .netstandard2.0 and .net6.0

### DIFF
--- a/ebay-oauth-csharp-client/ebay-oauth-csharp-client.csproj
+++ b/ebay-oauth-csharp-client/ebay-oauth-csharp-client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>eBay.ApiClient.Auth.oAuth2</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/ebay-oauth-csharp-client/ebay-oauth-csharp-client.csproj
+++ b/ebay-oauth-csharp-client/ebay-oauth-csharp-client.csproj
@@ -8,7 +8,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="YamlDotNet" Version="13.1.1" />
-    <PackageReference Include="RestSharp" Version="110.2.0" />
+	<!-- DO NOT INCREASE RestSharper VERSION-->
+    <PackageReference Include="RestSharp" Version="108.0.2" />
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/ebay-oauth-csharp-client/ebay-oauth-csharp-client.nuspec
+++ b/ebay-oauth-csharp-client/ebay-oauth-csharp-client.nuspec
@@ -15,12 +15,19 @@
     <releaseNotes>Fix of https://github.com/eBay/ebay-oauth-csharp-client/issues/2</releaseNotes>
     <copyright>Copyright 2018-2019 eBay Inc.</copyright>
     <dependencies>
-      <group targetFramework=".NET 6">
+      <group targetFramework="net6.0">
         <dependency id="YamlDotNet" version="13.1.1" />
         <dependency id="RestSharp" version="110.2.0" />
         <dependency id="log4net" version="2.0.15" />
         <dependency id="Newtonsoft.Json" version="13.0.3" />
       </group>
+      <group targetFramework="netstandard2.0">
+        <dependency id="YamlDotNet" version="13.1.1" />
+        <dependency id="RestSharp" version="110.2.0" />
+        <dependency id="log4net" version="2.0.15" />
+        <dependency id="Newtonsoft.Json" version="13.0.3" />
+      </group>
+        
     </dependencies>
     <tags>eBay API OAuth</tags>
   </metadata>


### PR DESCRIPTION
All of this project's dependencies either target `.net standard 2.0` or both  `.net standard 2.0` _and_ `.net 6.0`.

Why not also make this project target both `.net standard 2.0` _and_ `.net 6.0` in order to open up the target audience for this library as much as possible?