### PR TITLE
Use PrivateAssets=compile to avoid exposing refs

### DIFF
--- a/ebay-oauth-csharp-client/ebay-oauth-csharp-client.csproj
+++ b/ebay-oauth-csharp-client/ebay-oauth-csharp-client.csproj
@@ -7,9 +7,9 @@
     <Folder Include="eBay\ApiClient\Auth\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="13.1.1" />
-    <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="log4net" Version="2.0.15" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="YamlDotNet" Version="13.1.1" PrivateAssets="compile" />
+    <PackageReference Include="RestSharp" Version="110.2.0" PrivateAssets="compile" />
+    <PackageReference Include="log4net" Version="2.0.15" PrivateAssets="compile" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" PrivateAssets="compile" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Use PrivateAssets=compile to avoid exposing refs

Use PrivateAssets=compile to avoid exposing references to downstream 
consumers.

Currently, all referenced packages' public API surfaces are exposed to 
consumers whether they want to use them or not. With this change 
consumers will only see the APIs as being available if they are 
referenced on purpose.